### PR TITLE
Fix(Models): Add missing students relationships

### DIFF
--- a/app/Models/Exam.php
+++ b/app/Models/Exam.php
@@ -88,9 +88,9 @@ class Exam extends Model
     public function getEligibleStudents()
     {
         if ($this->stream_id) {
-            return $this->stream->students();
+            return $this->stream->students;
         }
-        return $this->class->students();
+        return $this->class->students;
     }
 
     // Calculate statistics for this exam

--- a/app/Models/SchoolClass.php
+++ b/app/Models/SchoolClass.php
@@ -22,4 +22,9 @@ class SchoolClass extends Model
     {
         return $this->hasMany(\App\Models\FeeStructure::class, 'class_id');
     }
+
+    public function students()
+    {
+        return $this->hasMany(Student::class, 'class_id');
+    }
 }

--- a/app/Models/Stream.php
+++ b/app/Models/Stream.php
@@ -27,4 +27,9 @@ class Stream extends Model
     {
         return $this->hasMany(SubjectTeacherStream::class, 'stream_id');
     }
+
+    public function students()
+    {
+        return $this->hasMany(Student::class, 'stream_id');
+    }
 }


### PR DESCRIPTION
Adds the `students` hasMany relationship to the `SchoolClass` and `Stream` models to resolve a `BadMethodCallException` in the `Exam` model's `getEligibleStudents` method.

Also updates the `getEligibleStudents` method to correctly access the `students` relationship.