### PR TITLE
Fix(Routes): Correct exam result route names

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -261,10 +261,10 @@ Route::prefix('schools/{school}')->group(function () {
     Route::get('/exams/{exam}/statistics', [ExamController::class, 'getStatistics'])->name('exams.statistics');
     
     // Individual Result Management
-    Route::get('/exams/{exam}/results/create', [ExamResultController::class, 'create'])->name('exam-results.create');
-    Route::post('/exams/{exam}/results', [ExamResultController::class, 'store'])->name('exam-results.store');
-    Route::put('/exam-results/{examResult}', [ExamResultController::class, 'update'])->name('exam-results.update');
-    Route::delete('/exam-results/{examResult}', [ExamResultController::class, 'destroy'])->name('exam-results.destroy');
+    Route::get('/exams/{exam}/results/create', [ExamResultController::class, 'create'])->name('exam_results.create');
+    Route::post('/exams/{exam}/results', [ExamResultController::class, 'store'])->name('exam_results.store');
+    Route::put('/exam-results/{examResult}', [ExamResultController::class, 'update'])->name('exam_results.update');
+    Route::delete('/exam-results/{examResult}', [ExamResultController::class, 'destroy'])->name('exam_results.destroy');
 });
 
 // Student and Parent Portal Routes


### PR DESCRIPTION
Changes the route names for the `ExamResultController` to use underscores instead of hyphens. This aligns the route names with the frontend code and resolves a Ziggy error where the `exam_results.create` route could not be found.