### PR TITLE
Fix(Controller): Remove redundant get() call

### DIFF
--- a/app/Http/Controllers/ExamResultController.php
+++ b/app/Http/Controllers/ExamResultController.php
@@ -12,7 +12,7 @@ class ExamResultController extends Controller
 {
     public function create(School $school, Exam $exam)
     {
-        $students = $exam->getEligibleStudents()->get();
+        $students = $exam->getEligibleStudents();
 
         return Inertia::render('SchoolAdmin/ExamResults/Create', [
             'school' => $school,


### PR DESCRIPTION
Removes an unnecessary `->get()` call on an already retrieved collection in the `ExamResultController`'s `create` method. This resolves an `ArgumentCountError` that occurred because the `get()` method was being called with no arguments.