### PR TITLE
Fix(Frontend): Correct exam result store route name

### DIFF
--- a/resources/js/Pages/SchoolAdmin/ExamResults/Create.jsx
+++ b/resources/js/Pages/SchoolAdmin/ExamResults/Create.jsx
@@ -24,7 +24,7 @@ export default function ExamResultCreate({ school, exam, students }) {
 
     const handleSubmit = (e) => {
         e.preventDefault();
-        post(route('exam-results.store', [school.id, exam.id]));
+        post(route('exam_results.store', [school.id, exam.id]));
     };
 
     const handleStudentSelect = (studentId) => {


### PR DESCRIPTION
Changes the route name for the form submission in `Create.jsx` to use an underscore instead of a hyphen. This aligns the route name with the backend and resolves a Ziggy error where the `exam-results.store` route could not be found.