### PR TITLE
Fix(Controller): Remove redundant get() call in bulkResultsImport

### DIFF
--- a/app/Http/Controllers/ExamController.php
+++ b/app/Http/Controllers/ExamController.php
@@ -109,7 +109,7 @@ class ExamController extends Controller
 
     public function bulkResultsImport(School $school, Exam $exam)
     {
-        $students = $exam->getEligibleStudents()->get();
+        $students = $exam->getEligibleStudents();
 
         return Inertia::render('SchoolAdmin/Exams/BulkImport', [
             'school' => $school,


### PR DESCRIPTION
Removes an unnecessary `->get()` call on an already retrieved collection in the `ExamController`'s `bulkResultsImport` method. This resolves an `ArgumentCountError` that occurred because the `get()` method was being called with no arguments.