### PR TITLE
Fix(Controller): Eager load user relationship in bulkResultsImport

### DIFF
--- a/app/Http/Controllers/ExamController.php
+++ b/app/Http/Controllers/ExamController.php
@@ -109,7 +109,7 @@ class ExamController extends Controller
 
     public function bulkResultsImport(School $school, Exam $exam)
     {
-        $students = $exam->getEligibleStudents();
+        $students = $exam->getEligibleStudents()->load('user');
 
         return Inertia::render('SchoolAdmin/Exams/BulkImport', [
             'school' => $school,


### PR DESCRIPTION
Updates the `ExamController`'s `bulkResultsImport` method to eager load the `user` relationship on the `students` collection. This provides the necessary data to the frontend to display student names and resolves a `TypeError` that occurred because the `user` object was undefined.