### PR TITLE
Fix(Controller): Eager load all required relationships in bulkResults…

### DIFF
--- a/app/Http/Controllers/ExamController.php
+++ b/app/Http/Controllers/ExamController.php
@@ -110,6 +110,7 @@ class ExamController extends Controller
     public function bulkResultsImport(School $school, Exam $exam)
     {
         $students = $exam->getEligibleStudents()->load('user');
+        $exam->load(['subject', 'class.streams']);
 
         return Inertia::render('SchoolAdmin/Exams/BulkImport', [
             'school' => $school,


### PR DESCRIPTION
…Import

Updates the `ExamController`'s `bulkResultsImport` method to eager load the `user`, `subject`, and `class.streams` relationships. This provides the necessary data to the frontend to display student names and other exam details, and resolves a `TypeError` that occurred because the related objects were undefined.